### PR TITLE
DEV-1030 Assign a new PID to the created fragment

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -21,6 +21,7 @@ from app.helpers.events_parser import (
 from app.helpers.xml_builder_vrt import XMLBuilderVRT
 from app.services.rabbit import RabbitClient
 from app.services.mediahaven import MediahavenClient
+from app.services.pid import PIDService
 
 
 class RetryException(Exception):
@@ -51,11 +52,12 @@ class BaseHandler(ABC):
 
 class EssenceLinkedHandler(BaseHandler):
     """ Class that will handle an incoming essence linked event """
-    def __init__(self, logger, mh_client, rabbit_client, routing_key):
+    def __init__(self, logger, mh_client, rabbit_client, routing_key, pid_service):
         self.log = logger
         self.mh_client = mh_client
         self.rabbit_client = rabbit_client
         self.routing_key = routing_key
+        self.pid_service = pid_service
 
     def _generate_get_metadata_request_xml(self, timestamp: datetime, correlation_id: str, media_id: str) -> str:
         """ Generates an xml for the getMetaDataRequest event.
@@ -99,7 +101,7 @@ class EssenceLinkedHandler(BaseHandler):
             message {str} -- Essence linked event XML message.
 
         Raises:
-            NackException -- When something happens that stops the handling.
+            NackError -- When something went wrong
         """
         self.log.info(
             'Start handling essence linked event',
@@ -118,6 +120,9 @@ class EssenceLinkedHandler(BaseHandler):
         # Parse the umid from the MediaHaven object
         umid = self._parse_umid(fragment)
 
+        # Get a pid to use for the new fragment
+        pid = self._get_pid()
+
         # Create fragment for main fragment
         create_fragment_response = self._create_fragment(umid)
 
@@ -125,13 +130,7 @@ class EssenceLinkedHandler(BaseHandler):
         fragment_id = self._parse_fragment_id(create_fragment_response)
 
         # Add Media_id to the newly created fragment
-        result = self._add_metadata(fragment_id, media_id)
-        if not result:
-            raise NackException(
-                f"Unable to update the metadata for fragment id: {fragment_id} and media id: {media_id}",
-                fragment_id=fragment_id,
-                media_id=media_id
-            )
+        self._add_metadata(fragment_id, media_id, pid)
 
         # Build metadata request XML
         xml = self._generate_get_metadata_request_xml(
@@ -213,7 +212,7 @@ class EssenceLinkedHandler(BaseHandler):
             )
         return fragment_id
 
-    def _retry(func):
+    def _retry(self, func):
         @functools.wraps(func)
         def wrapper(self, *args, **kwargs):
             delay = 1
@@ -234,21 +233,81 @@ class EssenceLinkedHandler(BaseHandler):
             return False
         return wrapper
 
-    @_retry
-    def _add_metadata(self, fragment_id: str, media_id: str) -> bool:
-        try:
-            result = self.mh_client.add_metadata_to_fragment(fragment_id, media_id)
-        except HTTPError as error:
-            if error.response.status_code == 404:
-                raise RetryException(f"Unable to update metadata for fragment_id: {fragment_id}")
-            else:
-                raise NackException(
-                    f"Unable to add MediaID metadata for fragment_id: {fragment_id}",
-                    error=error,
-                    fragment_id=fragment_id,
-                    media_id=media_id,
-                )
-        return result
+    def _get_pid(self) -> str:
+        """ Fetches a PID from the PID service.
+        
+        Raises:
+            NackException -- If unable to get a PID after X tries
+
+        Returns:
+            str -- The generated PID
+        """
+        @self._retry
+        def _internal_get_pid(self) -> str:
+            """ Actual method that will fetch a PID.
+
+            Raises:
+                RetryException -- If no valid PID is returned and we need to retry.
+            """
+            pid = self.pid_service.get_pid()
+            if not pid:
+                raise RetryException("Unable to get a pid")
+            return pid
+
+        pid = _internal_get_pid(self)
+        if not pid:
+            raise NackException("Unable to get a pid", requeue=True)
+        return pid
+
+    def _add_metadata(self, fragment_id: str, media_id: str, pid: str):
+        """ Adds the media ID and PID as metadata to the fragment.
+
+        This method is called after getting a success back from MH when sending out
+        a request creating the fragment. However with how MH works, it is possible
+        that the fragment has not yet been created. This result in a 404 response. We
+        will retry X times with an exponential back-off in that. If unsuccessful after
+        those X time we'll send a NackException.
+
+        Another type of HTTP error will result in a NackException.
+
+        As we actually only expect a 204 back from MH, another status code
+        in the success range (e.g. 200) will be seen as unsuccessful. This
+        also result in a NackException.
+
+        Arguments:
+            fragment_id -- ID of fragment to add the metadata to.
+            media_id -- Media ID to add as metadata.
+            pid -- PID to add as metadata.
+
+        Raises:
+            NackException -- When we were unable to add the metadata (see above).
+        """
+        @self._retry
+        def _internal_add_metadata(self) -> bool:
+            """ Actual method that will add the metadata
+
+            Raises:
+                RetryException -- When we get a 404 back from MH and need to retry.
+                NackException -- When we get a HTTP error back from MH that is not a 404.
+            """
+            try:
+                return self.mh_client.add_metadata_to_fragment(fragment_id, media_id, pid)
+            except HTTPError as error:
+                if error.response.status_code == 404:
+                    raise RetryException(f"Unable to update metadata for fragment_id: {fragment_id}")
+                else:
+                    raise NackException(
+                        f"Unable to add MediaID metadata for fragment_id: {fragment_id}",
+                        error=error,
+                        fragment_id=fragment_id,
+                        media_id=media_id,
+                    )
+        if not _internal_add_metadata(self):
+            raise NackException(
+                f"Unable to update the metadata for fragment id: {fragment_id} and media id: {media_id}",
+                fragment_id=fragment_id,
+                media_id=media_id
+            )
 
 
 class DeleteFragmentHandler(BaseHandler):
@@ -402,6 +461,7 @@ class EventListener:
         except AMQPConnectionError as error:
             self.log.error("Connection to RabbitMQ failed.")
             raise error
+        self.pid_service = PIDService(self.config["pid-service"]["URL"])
         self.essence_linked_rk = self.config["rabbitmq"]["essence_linked_routing_key"]
         self.essence_unlinked_rk = self.config["rabbitmq"]["essence_unlinked_routing_key"]
         self.object_deleted_rk = self.config["rabbitmq"]["object_deleted_routing_key"]
@@ -421,7 +481,8 @@ class EventListener:
                 self.log,
                 self.mh_client,
                 self.rabbit_client,
-                self.get_metadata_rk
+                self.get_metadata_rk,
+                self.pid_service
             )
         if routing_key == self.essence_unlinked_rk:
             return EssenceUnlinkedHandler(self.log, self.mh_client)

--- a/app/helpers/retry.py
+++ b/app/helpers/retry.py
@@ -1,0 +1,41 @@
+import functools
+import time
+
+from viaa.configuration import ConfigParser
+from viaa.observability import logging
+
+configParser = ConfigParser()
+log = logging.get_logger(__name__, config=configParser)
+
+
+class RetryException(Exception):
+    """ Exception raised when an action needs to be retried
+    in combination with _retry decorator"""
+    pass
+
+
+DELAY = 1
+BACKOFF = 2
+NUMBER_OF_TRIES = 5
+
+
+def retry(exceptions):
+    def decorator_retry(func):
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            delay = DELAY
+            tries = NUMBER_OF_TRIES
+            while tries:
+                tries -= 1
+                try:
+                    return func(self, *args, **kwargs)
+                except exceptions as error:
+                    log.debug(
+                        f"{error}. Retrying in {delay} seconds.",
+                        try_count=NUMBER_OF_TRIES - tries
+                    )
+                    time.sleep(delay)
+                    delay *= BACKOFF
+            return False
+        return wrapper
+    return decorator_retry

--- a/app/services/mediahaven.py
+++ b/app/services/mediahaven.py
@@ -131,15 +131,15 @@ class MediahavenClient:
         return response.status_code == 204
 
     @__authenticate
-    def add_metadata_to_fragment(self, fragment_id: str, media_id: str) -> bool:
+    def add_metadata_to_fragment(self, fragment_id: str, media_id: str, pid: str) -> bool:
         headers = self._construct_headers()
 
         # Construct the URL to POST to
         url = f'{self.url}{fragment_id}'
 
         # Create the payload
-        sidecar = self._construct_metadata(media_id)
-        data = {"metadata": sidecar, "reason": "essenceLinked: add mediaID to fragment"}
+        sidecar = self._construct_metadata(media_id, pid)
+        data = {"metadata": sidecar, "reason": "essenceLinked: add mediaID and PID to fragment"}
 
         # Send the POST request, as multipart/form-data
         response = requests.post(url, headers=headers, files=data)
@@ -153,18 +153,22 @@ class MediahavenClient:
 
         return response.status_code == 204
 
-    def _construct_metadata(self, media_id: str) -> str:
+    def _construct_metadata(self, media_id: str, pid: str) -> str:
         """Create the sidecar XML to upload the media id metadata.
-
-        TODO Rework this into the XML_BUILDER.
-
+W
         Returns:
             str -- The metadata sidecar XML.
         """
         root = etree.Element(f"{{{NAMESPACE_MHS}}}Sidecar", nsmap=NSMAP, version="20.1")
+        # /Dynamic
         dynamic = etree.SubElement(root, f"{{{NAMESPACE_MHS}}}Dynamic")
+        # /Dynamic/dc_identifier_localid
         etree.SubElement(dynamic, "dc_identifier_localid").text = media_id
+        # /Dynamic/PID
+        etree.SubElement(dynamic, "PID").text = pid
+        # /Dynamic/dc_identifier_localids
         local_ids = etree.SubElement(dynamic, "dc_identifier_localids")
+        # /Dynamic/dc_identifier_localids/MEDIA_ID
         etree.SubElement(local_ids, "MEDIA_ID").text = media_id
 
         return etree.tostring(

--- a/app/services/pid.py
+++ b/app/services/pid.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import requests
+from requests.exceptions import RequestException
+
+from viaa.configuration import ConfigParser
+from viaa.observability import logging
+
+configParser = ConfigParser()
+log = logging.get_logger(__name__, config=configParser)
+
+
+class PIDService():
+    """Abstraction to the pid-generating service.
+    See: https://github.com/viaacode/pid_webservice
+    The service returns a JSON as such:
+    ```json
+    [
+        {
+            "id": "j96059k22s",
+            "number": 1
+        }
+    ]
+    ```
+    """
+
+    def __init__(self, url: str):
+        self.url = url
+
+    def get_pid(self) -> str:
+        """ Fetches a PID via a GET call to the PID Service endpoint """
+        try:
+            resp = requests.get(self.url)
+        except RequestException:
+            return
+
+        log.debug(f"Response is: {resp.raw}")
+
+        try:
+            pid = resp.json()[0]["id"]
+        except (IndexError, KeyError):
+            return
+
+        return pid

--- a/app/services/pid.py
+++ b/app/services/pid.py
@@ -4,6 +4,7 @@
 import requests
 from requests.exceptions import RequestException
 
+from app.helpers.retry import retry
 from viaa.configuration import ConfigParser
 from viaa.observability import logging
 
@@ -28,18 +29,11 @@ class PIDService():
     def __init__(self, url: str):
         self.url = url
 
+    @retry((RequestException, IndexError, KeyError))
     def get_pid(self) -> str:
         """ Fetches a PID via a GET call to the PID Service endpoint """
-        try:
-            resp = requests.get(self.url)
-        except RequestException:
-            return
-
+        resp = requests.get(self.url)
         log.debug(f"Response is: {resp.raw}")
-
-        try:
-            pid = resp.json()[0]["id"]
-        except (IndexError, KeyError):
-            return
+        pid = resp.json()[0]["id"]
 
         return pid

--- a/tests/helpers/test_retry.py
+++ b/tests/helpers/test_retry.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+from app.helpers.retry import retry, RetryException, NUMBER_OF_TRIES, DELAY, BACKOFF
+
+
+@patch('time.sleep')
+def test_retry(time_sleep_mock):
+    function_mock = MagicMock()
+    function_mock.side_effect = RetryException
+
+    @retry(RetryException)
+    def func(self):
+        function_mock()
+
+    # Execute the decorated method
+    func(MagicMock())
+
+    # Test if function was executed multiple times
+    assert function_mock.call_count == NUMBER_OF_TRIES
+
+    # Test if time.sleep was executed multiple times
+    assert time_sleep_mock.call_count == NUMBER_OF_TRIES
+
+    # Test exponential backoff
+    assert time_sleep_mock.call_args_list[0][0][0] == DELAY
+    for i in range(1, NUMBER_OF_TRIES):
+        prev_val = time_sleep_mock.call_args_list[i-1][0][0]
+        assert time_sleep_mock.call_args_list[i][0][0] == prev_val*BACKOFF

--- a/tests/services/test_mediahaven.py
+++ b/tests/services/test_mediahaven.py
@@ -15,12 +15,13 @@ class TestMediahaven:
         cfg = {"mediahaven": {"host": "host"}}
         client = MediahavenClient(cfg)
         media_id = "media id"
+        pid = "pid"
 
         # Load in XML schema
         schema = etree.XMLSchema(file=construct_filename("mhs.xsd"))
 
         # Parse essence event linked as tree
-        xml = client._construct_metadata(media_id)
+        xml = client._construct_metadata(media_id, pid)
         tree = etree.parse(BytesIO(xml.encode("utf-8")))
 
         # Assert validness according to schema
@@ -34,3 +35,4 @@ class TestMediahaven:
             "mhs:Dynamic/dc_identifier_localids/MEDIA_ID", namespaces=NSMAP
         )
         assert m_id_element[0].text == media_id
+        assert tree.xpath("mhs:Dynamic/PID", namespaces=NSMAP)[0].text == pid

--- a/tests/services/test_mediahaven.py
+++ b/tests/services/test_mediahaven.py
@@ -11,7 +11,7 @@ from tests.resources.resources import load_xml_resource, construct_filename
 
 
 class TestMediahaven:
-    def test_construct_metadata(mock_mediahaven):
+    def test_construct_metadata(self):
         cfg = {"mediahaven": {"host": "host"}}
         client = MediahavenClient(cfg)
         media_id = "media id"

--- a/tests/services/test_pid.py
+++ b/tests/services/test_pid.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from unittest.mock import patch
+
+import pytest
+from requests.exceptions import RequestException
+
+from app.services.pid import PIDService
+
+PID = "j96059k22s"
+VALID_DICT = {
+    "id": f"{PID}",
+    "number": 1,
+}
+VALID_RESPONSE = [VALID_DICT]
+
+
+class TestPIDservice:
+    @pytest.fixture
+    def pid_service(self):
+        return PIDService("http://localhost")
+
+    @patch('requests.get')
+    def test_get_pid(self, get_mock, pid_service):
+        get_mock().json.return_value = VALID_RESPONSE
+        assert pid_service.get_pid() == PID
+
+    @patch('requests.get', side_effect=RequestException)
+    def test_get_pid_request_exception(self, get_mock, pid_service):
+        assert not pid_service.get_pid()
+
+    @pytest.mark.parametrize("error", [IndexError, KeyError])
+    @patch('requests.get')
+    def test_get_pid_parse_error(self, get_mock, error, pid_service):
+        get_mock().json.side_effect = IndexError
+        assert not pid_service.get_pid()

--- a/tests/services/test_pid.py
+++ b/tests/services/test_pid.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 from requests.exceptions import RequestException
 
+from app.helpers.retry import NUMBER_OF_TRIES
 from app.services.pid import PIDService
 
 PID = "j96059k22s"
@@ -26,12 +27,16 @@ class TestPIDservice:
         get_mock().json.return_value = VALID_RESPONSE
         assert pid_service.get_pid() == PID
 
+    @patch('time.sleep')
     @patch('requests.get', side_effect=RequestException)
-    def test_get_pid_request_exception(self, get_mock, pid_service):
+    def test_get_pid_request_exception(self, get_mock, time_sleep_mock, pid_service):
         assert not pid_service.get_pid()
+        assert time_sleep_mock.call_count == NUMBER_OF_TRIES
 
     @pytest.mark.parametrize("error", [IndexError, KeyError])
+    @patch('time.sleep')
     @patch('requests.get')
-    def test_get_pid_parse_error(self, get_mock, error, pid_service):
+    def test_get_pid_parse_error(self, get_mock, time_sleep_mock, error, pid_service):
         get_mock().json.side_effect = IndexError
         assert not pid_service.get_pid()
+        assert time_sleep_mock.call_count == NUMBER_OF_TRIES


### PR DESCRIPTION
As the incoming Media ID is an unique identifier it should also be
mapped to an unique identifier on our side. So we first generate a
PID. The PID then gets added as metadata together with the Media ID
in the supdate metadadata call to MH.