### PR TITLE
DEV-1031 Retry metadata update when a 403 occurs

### DIFF
--- a/app/services/mediahaven.py
+++ b/app/services/mediahaven.py
@@ -149,8 +149,10 @@ class MediahavenClient:
             # AuthenticationException triggers a retry with a new token
             raise AuthenticationException(response.text)
 
-        if response.status_code == 404:
-            raise RetryException(f"Unable to update metadata for fragment_id: {fragment_id}")
+        if response.status_code in (404, 403):
+            raise RetryException(
+                f"Unable to update metadata for fragment_id: {fragment_id} with status code: {response.status_code}",
+            )
 
         # If there is an HTTP error, raise it
         response.raise_for_status()

--- a/tests/services/test_mediahaven.py
+++ b/tests/services/test_mediahaven.py
@@ -2,26 +2,46 @@
 # -*- coding: utf-8 -*-
 
 from io import BytesIO
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 
+import pytest
 from lxml import etree
 
+from app.helpers.retry import NUMBER_OF_TRIES
 from app.services.mediahaven import MediahavenClient, NSMAP
-from tests.resources.resources import load_xml_resource, construct_filename
+from tests.resources.resources import construct_filename
 
 
 class TestMediahaven:
-    def test_construct_metadata(self):
-        cfg = {"mediahaven": {"host": "host"}}
-        client = MediahavenClient(cfg)
+    @pytest.fixture
+    @patch.object(
+        MediahavenClient,
+        "_MediahavenClient__get_token",
+        return_value={"access_token": "Bear with me"},
+    )
+    def mediahaven_client(self, mhs_get_token_mock):
+        mh_config_dict = {
+            "mediahaven": {
+                "host": "mediahaven",
+                "username": "user",
+                "password": "pass",
+            }
+        }
+
+        mhs = MediahavenClient(mh_config_dict)
+        # Patch out __get_token so it doesn't send a request to MediaHaven
+        mhs._MediahavenClient__get_token = mhs_get_token_mock
+        return mhs
+
+    def test_construct_metadata(self, mediahaven_client):
         media_id = "media id"
         pid = "pid"
 
         # Load in XML schema
         schema = etree.XMLSchema(file=construct_filename("mhs.xsd"))
 
-        # Parse essence event linked as tree
-        xml = client._construct_metadata(media_id, pid)
+        # Create the sidecar XML
+        xml = mediahaven_client._construct_metadata(media_id, pid)
         tree = etree.parse(BytesIO(xml.encode("utf-8")))
 
         # Assert validness according to schema
@@ -36,3 +56,30 @@ class TestMediahaven:
         )
         assert m_id_element[0].text == media_id
         assert tree.xpath("mhs:Dynamic/PID", namespaces=NSMAP)[0].text == pid
+
+    @pytest.mark.parametrize(
+        "status, code, message",
+        [(404, "ENOTFND", "Resource cannot be found"), (403, "ENOACCES", "User has no access")]
+    )
+    @patch('requests.post')
+    @patch('time.sleep')
+    def test_add_metadata_to_fragment_retry(self, sleep_mock, update_mock, status, code, message, mediahaven_client):
+        # Construct response message
+        response = {
+            "status": status,
+            "message": message,
+            "code": code,
+        }
+
+        # Mock response data
+        response_mock = MagicMock()
+        response_mock.json.return_value = response
+        response_mock.status_code = status
+        update_mock.return_value = response_mock
+
+        fragment_id = "fragment_id"
+        media_id = "media_id"
+        pid = "PID"
+
+        assert not mediahaven_client.add_metadata_to_fragment(fragment_id, media_id, pid)
+        assert sleep_mock.call_count == NUMBER_OF_TRIES


### PR DESCRIPTION
In the case of an essence linked, after creating a fragment we
immediately send an update metadata call. This sometimes results in a
"403 - no access", although the same user executes the create fragment
as well as the update metadata calls.

The assumption is that MH first creates the fragment but has not yet
correctly applied the rights. As a fix we will retry sending the
request with an exponential back-off when getting a 403 back.