### PR TITLE
DEV-1042 Exhaustive identity check

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -4,6 +4,7 @@
 import time
 from abc import ABC, abstractmethod
 from datetime import datetime
+from typing import List, Tuple
 
 from lxml.etree import XMLSyntaxError
 from pika.exceptions import AMQPConnectionError
@@ -42,7 +43,7 @@ class BaseHandler(ABC):
     def handle_event(self, message: str):
         pass
 
-    def _get_fragment(self, query_key_values: str, expected_amount: int = -1) -> dict:
+    def _get_fragment(self, query_key_values: List[Tuple[str, object]], expected_amount: int = -1) -> dict:
         """ Gets a fragment based on a query given a list of keys and values.
 
         Also checks if the actual amount of results is what we expect. If the expected

--- a/app/services/mediahaven.py
+++ b/app/services/mediahaven.py
@@ -4,6 +4,7 @@
 import functools
 
 import requests
+import urllib
 from lxml import etree
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import RequestException
@@ -68,14 +69,18 @@ class MediahavenClient:
         }
 
     @__authenticate
-    def get_fragment(self, query_key: str, value: str) -> dict:
+    def get_fragment(self, query_key_values: list) -> dict:
         headers = self._construct_headers()
 
-        # Construct URL query parameters
-        params: dict = {
-            "q": f'+({query_key}:"{value}")',
+        # Construct URL query parameters as "+(k1:v1) +(k2:v2) +(k3:v3) ..."
+        query = " ".join([f'+({":".join(map(str, k_v))})' for k_v in query_key_values])
+
+        params_dict: dict = {
+            "q": query,
             "nrOfResults": 1,
         }
+        # Encode the spaces in the query parameters as %20 and not +
+        params = urllib.parse.urlencode(params_dict, quote_via=urllib.parse.quote)
 
         # Send the GET request
         response = requests.get(self.url, headers=headers, params=params,)

--- a/app/services/mediahaven.py
+++ b/app/services/mediahaven.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import functools
+from typing import List, Tuple
 
 import requests
 import urllib
@@ -69,7 +70,7 @@ class MediahavenClient:
         }
 
     @__authenticate
-    def get_fragment(self, query_key_values: list) -> dict:
+    def get_fragment(self, query_key_values: List[Tuple[str, object]]) -> dict:
         headers = self._construct_headers()
 
         # Construct URL query parameters as "+(k1:v1) +(k2:v2) +(k3:v3) ..."

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,6 +11,7 @@ from lxml import etree
 from requests.exceptions import HTTPError, RequestException
 
 from app.app import (
+    BaseHandler,
     EssenceLinkedHandler,
     EssenceUnlinkedHandler,
     EventListener,
@@ -36,7 +37,7 @@ class TestEventListener:
     @patch('app.app.RabbitClient')
     def event_listener(self, rabbit_client, mh_client, pid_service):
         """ Creates an event listener with mocked rabbit client, MH client and
-        PID Service
+        PID Service.
         """
         return EventListener()
 
@@ -177,7 +178,51 @@ class TestEventListener:
         assert mock_nack.call_args[0][3] == 1
 
 
-class TestEventLinkedHandler:
+class AbstractBaseHandler(ABC):
+    @pytest.mark.parametrize(
+        "actual_amount,expected_amount",
+        [(1, 1), (2, -1)]
+    )
+    def test_get_fragment(self, actual_amount, expected_amount, handler):
+        result_dict = {"TotalNrOfResults": actual_amount}
+        mh_client_mock = handler.mh_client
+        mh_client_mock.get_fragment.return_value = result_dict
+
+        assert handler._get_fragment("key", "value", expected_amount) == result_dict
+        assert mh_client_mock.get_fragment.call_count == 1
+        assert mh_client_mock.get_fragment.call_args[0][0] == "key"
+        assert mh_client_mock.get_fragment.call_args[0][1] == "value"
+
+    def test_get_fragment_nr_of_results_mismatch(self, handler):
+        result_dict = {"TotalNrOfResults": 1}
+        mh_client_mock = handler.mh_client
+        mh_client_mock.get_fragment.return_value = result_dict
+
+        with pytest.raises(NackException):
+            handler._get_fragment("key", "value", 2)
+        assert mh_client_mock.get_fragment.call_count == 1
+        assert mh_client_mock.get_fragment.call_args[0][0] == "key"
+        assert mh_client_mock.get_fragment.call_args[0][1] == "value"
+
+    def test_get_fragment_http_error(self, http_error, handler):
+        mh_client_mock = handler.mh_client
+        # Raise a HTTP Error when calling method
+        handler.mh_client.get_fragment.side_effect = http_error
+
+        with pytest.raises(NackException) as error:
+            handler._get_fragment("key", "value")
+        assert not error.value.requeue
+        assert error.value.kwargs["error"] == http_error
+        assert error.value.kwargs["error_response"] == http_error.response.text
+        assert error.value.kwargs["query_key"] == "key"
+        assert error.value.kwargs["query_value"] == "value"
+
+        assert mh_client_mock.get_fragment.call_count == 1
+        assert mh_client_mock.get_fragment.call_args[0][0] == "key"
+        assert mh_client_mock.get_fragment.call_args[0][1] == "value"
+
+
+class TestEventLinkedHandler(AbstractBaseHandler):
     @pytest.fixture
     def handler(self):
         """ Creates an essence linked handler with a mocked logger, rabbit client,
@@ -235,7 +280,11 @@ class TestEventLinkedHandler:
     ):
         handler.handle_event("irrelevant")
         assert mock_parse_event.call_count == 1
-        assert mock_get_fragment.call_count == 1
+        assert mock_get_fragment.call_count == 2
+        assert mock_get_fragment.call_args_list[0][0][0] == "s3_object_key"
+        assert mock_get_fragment.call_args_list[0][0][2] == 1
+        assert mock_get_fragment.call_args_list[1][0][0] == "dc_identifier_localid"
+        assert mock_get_fragment.call_args_list[1][0][2] == 0
         assert mock_parse_umid.call_count == 1
         assert mock_create_fragment.call_count == 1
         assert mock_parse_fragment_id.call_count == 1
@@ -246,30 +295,6 @@ class TestEventLinkedHandler:
         assert handler.rabbit_client.send_message.call_args[0][0] == "xml"
         assert handler.rabbit_client.send_message.call_args[0][1] == handler.routing_key
 
-    def test_get_fragment(self, handler):
-        mh_client_mock = handler.mh_client
-        mh_client_mock.get_fragment.return_value = {}
-
-        assert handler._get_fragment("file") == {}
-        assert mh_client_mock.get_fragment.call_count == 1
-        assert mh_client_mock.get_fragment.call_args[0][0] == "s3_object_key"
-        assert mh_client_mock.get_fragment.call_args[0][1] == "file"
-
-    def test_get_fragment_http_error(self, http_error, handler):
-        mh_client_mock = handler.mh_client
-        # Raise a HTTP Error when calling method
-        handler.mh_client.get_fragment.side_effect = http_error
-
-        with pytest.raises(NackException) as error:
-            handler._get_fragment("file")
-
-        assert error.value.kwargs["error"] == http_error
-        assert error.value.kwargs["error_response"] == http_error.response.text
-        assert error.value.kwargs["s3_object_key"] == "file"
-
-        assert mh_client_mock.get_fragment.call_count == 1
-        assert mh_client_mock.get_fragment.call_args[0][0] == "s3_object_key"
-        assert mh_client_mock.get_fragment.call_args[0][1] == "file"
 
     def test_parse_umid(self, handler):
         object_id = "object id"
@@ -402,38 +427,12 @@ class TestEventLinkedHandler:
         assert error.value.kwargs.get("error") is None
 
 
-class AbstractTestDeleteFragmentHandler(ABC):
-
+class AbstractTestDeleteFragmentHandler(AbstractBaseHandler):
     def test_parse_event_invalid(self, handler):
         event = b""
         with pytest.raises(NackException) as error:
             handler._parse_event(event)
         assert not error.value.requeue
-
-    def test_get_fragment(self, handler):
-        mh_client_mock = handler.mh_client
-        mh_client_mock.get_fragment.return_value = {}
-
-        assert handler._get_fragment("media_id") == {}
-        assert mh_client_mock.get_fragment.call_count == 1
-        assert mh_client_mock.get_fragment.call_args[0][0] == "dc_identifier_localid"
-        assert mh_client_mock.get_fragment.call_args[0][1] == "media_id"
-
-    def test_get_fragment_http_error(self, http_error, handler):
-        mh_client_mock = handler.mh_client
-        # Raise a HTTP Error when calling method
-        handler.mh_client.get_fragment.side_effect = http_error
-
-        with pytest.raises(NackException) as error:
-            handler._get_fragment("media_id")
-        assert not error.value.requeue
-        assert error.value.kwargs["error"] == http_error
-        assert error.value.kwargs["error_response"] == http_error.response.text
-        assert error.value.kwargs["dc_identifier_localid"] == "media_id"
-
-        assert mh_client_mock.get_fragment.call_count == 1
-        assert mh_client_mock.get_fragment.call_args[0][0] == "dc_identifier_localid"
-        assert mh_client_mock.get_fragment.call_args[0][1] == "media_id"
 
     def test_parse_fragment_id(self, handler):
         fragment_id = "fragment id"
@@ -521,6 +520,8 @@ class TestEventUnlinkedHandler(AbstractTestDeleteFragmentHandler):
             handler.handle_event("irrelevant")
         assert not error.value.requeue
         assert mock_parse_event.call_count == 1
+        assert mock_get_fragment.call_args[0][0] == "dc_identifier_localid"
+        assert mock_get_fragment.call_args[0][2] == 1
         assert mock_get_fragment.call_count == 1
         assert mock_parse_fragment.call_count == 1
         assert mock_delete_fragment.call_count == 1
@@ -558,6 +559,8 @@ class TestObjectDeletedHandler(AbstractTestDeleteFragmentHandler):
             handler.handle_event("irrelevant")
         assert not error.value.requeue
         assert mock_parse_event.call_count == 1
+        assert mock_get_fragment.call_args[0][0] == "dc_identifier_localid"
+        assert mock_get_fragment.call_args[0][2] == 1
         assert mock_get_fragment.call_count == 1
         assert mock_parse_fragment.call_count == 1
         assert mock_delete_fragment.call_count == 1


### PR DESCRIPTION
There needs to be some checks on the state of the ingested media
before "applying" an incoming essence event.

Essence linked:
Check if there is only one media object with the incoming
s3 object key. Also check if there is no media object already with
the incoming media ID.

Essence Unlinked / Object Deleted:
Check if there is only one media object with the incoming media ID.