### PR TITLE
DEV-1060 Log invalid event

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -6,7 +6,6 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import List, Tuple
 
-from lxml.etree import XMLSyntaxError
 from pika.exceptions import AMQPConnectionError
 from requests.exceptions import HTTPError, RequestException
 
@@ -16,6 +15,7 @@ from app.helpers.events_parser import (
     EssenceEvent,
     EssenceLinkedEvent,
     EssenceUnlinkedEvent,
+    InvalidEventException,
     ObjectDeletedEvent,
 )
 from app.helpers.xml_builder_vrt import XMLBuilderVRT
@@ -179,7 +179,7 @@ class EssenceLinkedHandler(BaseHandler):
     def _parse_event(self, message: str) -> EssenceLinkedEvent:
         try:
             event = EssenceLinkedEvent(message)
-        except XMLSyntaxError as error:
+        except InvalidEventException as error:
             raise NackException(
                 "Unable to parse the incoming essence linked event",
                 error=error,
@@ -377,7 +377,7 @@ class EssenceUnlinkedHandler(DeleteFragmentHandler):
         )
         try:
             event = EssenceUnlinkedEvent(message)
-        except XMLSyntaxError as error:
+        except InvalidEventException as error:
             raise NackException(
                 "Unable to parse the incoming essence unlinked event",
                 error=error,
@@ -395,7 +395,7 @@ class ObjectDeletedHandler(DeleteFragmentHandler):
         )
         try:
             event = ObjectDeletedEvent(message)
-        except XMLSyntaxError as error:
+        except InvalidEventException as error:
             raise NackException(
                 "Unable to parse the incoming object deleted event",
                 error=error,

--- a/app/helpers/events_parser.py
+++ b/app/helpers/events_parser.py
@@ -14,28 +14,52 @@ XPATHS = {
 }
 
 
+class InvalidEventException(Exception):
+    def __init__(self, message, **kwargs):
+        self.message = message
+        self.kwargs = kwargs
+
+
 class EssenceEvent(ABC):
     """Abstract class for an XML Essence Event"""
     def __init__(self, xml):
-        self.xml_element = self._get_essence_linked_event(xml)
+        self.xml_element = self._get_essence_event(xml)
         self.timestamp = self._get_xpath_from_event(XPATHS["timestamp"])
         self.media_id = self._get_xpath_from_event(XPATHS["media_id"])
 
-    def _get_essence_linked_event(self, xml: str):
-        """Parse the input XML to a DOM"""
-        tree = etree.parse(BytesIO(xml))
-        return tree.xpath(
-            f"/p:{self.root_tag}", namespaces={"p": VRT_NAMESPACE}
-        )[0]
+    def _get_essence_event(self, xml: str):
+        """Parse the input XML to a DOM
 
-    def _get_xpath_from_event(self, xpath) -> str:
-        """Parses based on an xpath, returns empty string if absent"""
+        Raises:
+            InvalidEventException -- When the XML is not valid.
+        """
+        try:
+            tree = etree.parse(BytesIO(xml))
+        except etree.XMLSyntaxError:
+            raise InvalidEventException("Event is not valid XML.")
+
+        try:
+            return tree.xpath(
+                f"/p:{self.root_tag}", namespaces={"p": VRT_NAMESPACE}
+            )[0]
+        except IndexError:
+            raise InvalidEventException(f"Event is not a '{self.root_tag}'.")
+
+    def _get_xpath_from_event(self, xpath, optional: bool = False) -> str:
+        """Parses value based on an xpath.
+
+        Raises:
+            InvalidEventException -- When XPATH is mandatory but not present
+        """
         try:
             return self.xml_element.xpath(
                 xpath, namespaces={"p": VRT_NAMESPACE}
             )[0].text
         except IndexError:
-            return ""
+            if optional:
+                return ""
+            else:
+                raise InvalidEventException(f"'{xpath}' is not present in the event.")
 
 
 class EssenceLinkedEvent(EssenceEvent):

--- a/tests/helpers/test_events_parser.py
+++ b/tests/helpers/test_events_parser.py
@@ -1,74 +1,80 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-from io import BytesIO
-
-from lxml import etree
+import pytest
 
 from app.helpers.events_parser import (
     EssenceLinkedEvent,
     EssenceUnlinkedEvent,
     ObjectDeletedEvent,
+    InvalidEventException,
 )
-from tests.resources.resources import load_xml_resource, construct_filename
+from tests.resources.resources import load_resource
 
 
-class TestEssenceLinkedEvent:
-    def test_essence_linked_event_xsd(self):
-        """Test if the essence event linked xml is valid for the XML schema."""
-
-        # Load in XML schema
-        schema = etree.XMLSchema(file=construct_filename("essenceEvents.xsd"))
-
-        # Parse essence linked event as tree
-        tree = etree.parse(BytesIO(load_xml_resource("essenceLinkedEvent.xml")))
-
-        # Assert validness according to schema
-        is_xml_valid = schema.validate(tree)
-        assert is_xml_valid
-
-    def test_essence_linked_event(self):
-        event = EssenceLinkedEvent(load_xml_resource("essenceLinkedEvent.xml"))
-        assert event.timestamp == "2019-09-24T17:21:28.787+02:00"
-        assert event.file == "file.mxf"
-        assert event.media_id == "media id"
+INVALID_ESSENCE_LINKED_EVENTS = [
+    "essenceLinkedEventFileMissing.xml",
+    "essenceLinkedEventMediaIdMissing.xml",
+    "essencelinkedEventTimestampMissing.xml",
+]
 
 
-class TestEssenceUnlinkedEvent:
-    def test_essence_unlinked_event_xsd(self):
-        """Test if the essence event unlinked xml is valid for the XML schema."""
-
-        # Load in XML schema
-        schema = etree.XMLSchema(file=construct_filename("essenceEvents.xsd"))
-
-        # Parse essence unlinked event as tree
-        tree = etree.parse(BytesIO(load_xml_resource("essenceUnlinkedEvent.xml")))
-
-        # Assert validness according to schema
-        is_xml_valid = schema.validate(tree)
-        assert is_xml_valid
-
-    def test_essence_unlinked_event(self):
-        event = EssenceUnlinkedEvent(load_xml_resource("essenceUnlinkedEvent.xml"))
-        assert event.timestamp == "2019-09-24T17:21:28.787+02:00"
-        assert event.media_id == "media id"
+INVALID_ESSENCE_UNLINKED_EVENTS = [
+    "essenceUnlinkedEventMediaIdMissing.xml",
+    "essenceUnlinkedEventTimestampMissing.xml",
+]
 
 
-class TestObjectDeletedEvent:
-    def test_object_deleted_event_xsd(self):
-        """Test if the object deleted event xml is valid for the XML schema."""
+INVALID_OBJECT_DELETED_EVENTS = [
+    "objectDeletedEventMediaIdMissing.xml",
+    "objectDeletedEventTimestampMissing.xml",
+]
 
-        # Load in XML schema
-        schema = etree.XMLSchema(file=construct_filename("essenceEvents.xsd"))
 
-        # Parse object deleted event as tree
-        tree = etree.parse(BytesIO(load_xml_resource("objectDeletedEvent.xml")))
+def test_essence_linked_event_valid():
+    event = EssenceLinkedEvent(load_resource("essenceLinkedEvent.xml"))
+    assert event.timestamp == "2019-09-24T17:21:28.787+02:00"
+    assert event.file == "file.mxf"
+    assert event.media_id == "media id"
 
-        # Assert validness according to schema
-        is_xml_valid = schema.validate(tree)
-        assert is_xml_valid
 
-    def test_object_deleted_event(self):
-        event = ObjectDeletedEvent(load_xml_resource("objectDeletedEvent.xml"))
-        assert event.timestamp == "2019-09-24T17:21:28.787+02:00"
-        assert event.media_id == "media id"
+@pytest.mark.parametrize("filename", INVALID_ESSENCE_LINKED_EVENTS)
+def test_essence_linked_event_invalid(filename):
+    with pytest.raises(InvalidEventException):
+        EssenceLinkedEvent(load_resource(filename))
+
+
+def test_essence_unlinked_event_valid():
+    event = EssenceUnlinkedEvent(load_resource("essenceUnlinkedEvent.xml"))
+    assert event.timestamp == "2019-09-24T17:21:28.787+02:00"
+    assert event.media_id == "media id"
+
+
+@pytest.mark.parametrize("filename", INVALID_ESSENCE_UNLINKED_EVENTS)
+def test_essence_unlinked_event_invalid(filename):
+    with pytest.raises(InvalidEventException):
+        EssenceUnlinkedEvent(load_resource(filename))
+
+
+def test_object_deleted_event_valid():
+    event = ObjectDeletedEvent(load_resource("objectDeletedEvent.xml"))
+    assert event.timestamp == "2019-09-24T17:21:28.787+02:00"
+    assert event.media_id == "media id"
+
+
+@pytest.mark.parametrize("filename", INVALID_OBJECT_DELETED_EVENTS)
+def test_object_deleted_event_invalid(filename):
+    with pytest.raises(InvalidEventException):
+        ObjectDeletedEvent(load_resource(filename))
+
+
+def test_invalid_xml():
+    with pytest.raises(InvalidEventException) as error:
+        EssenceLinkedEvent(b"")
+    assert error.value.message == "Event is not valid XML."
+
+
+def test_essence_linked_wrong_type():
+    with pytest.raises(InvalidEventException) as error:
+        EssenceLinkedEvent(load_resource("essenceUnlinkedEvent.xml"))
+    assert EssenceLinkedEvent.root_tag in error.value.message

--- a/tests/resources/essenceEvents.xsd
+++ b/tests/resources/essenceEvents.xsd
@@ -3,31 +3,6 @@
            xmlns:tns="http://www.vrt.be/mig/viaa/api"
            xmlns:xs="http://www.w3.org/2001/XMLSchema"
            xmlns:ebu="urn:ebu:metadata-schema:ebuCore_2012">
-    <xs:element name="essenceLinkedEvent">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="timestamp" type="xs:dateTime" />
-                <xs:element name="file" type="xs:string" />
-                <xs:element name="mediaId" type="xs:string" />
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="objectDeletedEvent">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="timestamp" type="xs:dateTime" />
-                <xs:element name="mediaId" type="xs:string" />
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
-    <xs:element name="essenceUnlinkedEvent">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:element name="timestamp" type="xs:dateTime" />
-                <xs:element name="mediaId" type="xs:string" />
-            </xs:sequence>
-        </xs:complexType>
-    </xs:element>
     <xs:element name="getMetadataRequest">
         <xs:complexType>
             <xs:sequence>

--- a/tests/resources/essenceLinkedEventFileMissing.xml
+++ b/tests/resources/essenceLinkedEventFileMissing.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0'?>
+<ns2:essenceLinkedEvent xmlns:ns2="http://www.vrt.be/mig/viaa/api" xmlns="http://www.vrt.be/mig/viaa" xmlns:ns3="http://purl.org/dc/elements/1.1/" xmlns:ns4="urn:ebu:metadata-schema:ebuCore_2012">
+  <ns2:timestamp>2019-09-24T17:21:28.787+02:00</ns2:timestamp>
+  <ns2:mediaId>media id</ns2:mediaId>
+</ns2:essenceLinkedEvent>

--- a/tests/resources/essenceLinkedEventMediaIdMissing.xml
+++ b/tests/resources/essenceLinkedEventMediaIdMissing.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0'?>
+<ns2:essenceLinkedEvent xmlns:ns2="http://www.vrt.be/mig/viaa/api" xmlns="http://www.vrt.be/mig/viaa" xmlns:ns3="http://purl.org/dc/elements/1.1/" xmlns:ns4="urn:ebu:metadata-schema:ebuCore_2012">
+  <ns2:timestamp>2019-09-24T17:21:28.787+02:00</ns2:timestamp>
+  <ns2:file>file.mxf</ns2:file>
+</ns2:essenceLinkedEvent>

--- a/tests/resources/essenceUnlinkedEventMediaIdMissing.xml
+++ b/tests/resources/essenceUnlinkedEventMediaIdMissing.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0'?>
+<ns2:essenceUnlinkedEvent xmlns:ns2="http://www.vrt.be/mig/viaa/api" xmlns="http://www.vrt.be/mig/viaa" xmlns:ns3="http://purl.org/dc/elements/1.1/" xmlns:ns4="urn:ebu:metadata-schema:ebuCore_2012">
+  <ns2:timestamp>2019-09-24T17:21:28.787+02:00</ns2:timestamp>
+</ns2:essenceUnlinkedEvent>

--- a/tests/resources/essenceUnlinkedEventTimestampMissing.xml
+++ b/tests/resources/essenceUnlinkedEventTimestampMissing.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0'?>
+<ns2:essenceUnlinkedEvent xmlns:ns2="http://www.vrt.be/mig/viaa/api" xmlns="http://www.vrt.be/mig/viaa" xmlns:ns3="http://purl.org/dc/elements/1.1/" xmlns:ns4="urn:ebu:metadata-schema:ebuCore_2012">
+  <ns2:mediaId>media id</ns2:mediaId>
+</ns2:essenceUnlinkedEvent>

--- a/tests/resources/essencelinkedEventTimestampMissing.xml
+++ b/tests/resources/essencelinkedEventTimestampMissing.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0'?>
+<ns2:essenceLinkedEvent xmlns:ns2="http://www.vrt.be/mig/viaa/api" xmlns="http://www.vrt.be/mig/viaa" xmlns:ns3="http://purl.org/dc/elements/1.1/" xmlns:ns4="urn:ebu:metadata-schema:ebuCore_2012">
+  <ns2:file>file.mxf</ns2:file>
+  <ns2:mediaId>media id</ns2:mediaId>
+</ns2:essenceLinkedEvent>

--- a/tests/resources/objectDeletedEventMediaIdMissing.xml
+++ b/tests/resources/objectDeletedEventMediaIdMissing.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0'?>
+<ns2:objectDeletedEvent xmlns:ns2="http://www.vrt.be/mig/viaa/api" xmlns="http://www.vrt.be/mig/viaa" xmlns:ns3="http://purl.org/dc/elements/1.1/" xmlns:ns4="urn:ebu:metadata-schema:ebuCore_2012">
+  <ns2:timestamp>2019-09-24T17:21:28.787+02:00</ns2:timestamp>
+</ns2:objectDeletedEvent>

--- a/tests/resources/objectDeletedEventTimestampMissing.xml
+++ b/tests/resources/objectDeletedEventTimestampMissing.xml
@@ -1,0 +1,4 @@
+<?xml version='1.0'?>
+<ns2:objectDeletedEvent xmlns:ns2="http://www.vrt.be/mig/viaa/api" xmlns="http://www.vrt.be/mig/viaa" xmlns:ns3="http://purl.org/dc/elements/1.1/" xmlns:ns4="urn:ebu:metadata-schema:ebuCore_2012">
+  <ns2:mediaId>media id</ns2:mediaId>
+</ns2:objectDeletedEvent>

--- a/tests/resources/resources.py
+++ b/tests/resources/resources.py
@@ -3,6 +3,7 @@
 
 import os
 
+
 def construct_filename(name):
     __location__ = os.path.realpath(
         os.path.join(os.getcwd(), os.path.dirname(__file__))
@@ -10,6 +11,7 @@ def construct_filename(name):
 
     return os.path.join(__location__, f"{name}")
 
-def load_xml_resource(name):
+
+def load_resource(name):
     content = open(construct_filename(name), "rb").read()
     return content


### PR DESCRIPTION
When an event is not valid log an error and stop the handling.

An event is not valid when:
  - a mandatory node is not present
  - the XML is invalid
  - the root tag is wrong