### PR TITLE
DEV-1063 Delete only the real fragment

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -43,6 +43,10 @@ class BaseHandler(ABC):
     def handle_event(self, message: str):
         pass
 
+    @abstractmethod
+    def _parse_event(self, message: str) -> EssenceEvent:
+        pass
+
     def _get_fragment(self, query_key_values: List[Tuple[str, object]], expected_amount: int = -1) -> dict:
         """ Gets a fragment based on a query given a list of keys and values.
 
@@ -317,7 +321,7 @@ class DeleteFragmentHandler(BaseHandler):
         media_id = event.media_id
 
         # Get the fragment based on the media_id
-        fragment = self._get_fragment([("dc_identifier_localid", media_id)], 1)
+        fragment = self._get_fragment([("dc_identifier_localid", media_id), ("IsFragment", 1)], 1)
 
         # Parse the fragment_id from the MediaHaven object
         fragment_id = self._parse_fragment_id(fragment)
@@ -331,10 +335,6 @@ class DeleteFragmentHandler(BaseHandler):
             )
 
         self.log.info(f"Successfully deleted fragment with ID: {fragment_id}")
-
-    @abstractmethod
-    def _parse_event(self, message: str) -> EssenceEvent:
-        pass
 
     def _parse_fragment_id(self, fragment: dict) -> str:
         try:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,7 +11,6 @@ from lxml import etree
 from requests.exceptions import HTTPError, RequestException
 
 from app.app import (
-    BaseHandler,
     EssenceLinkedHandler,
     EssenceUnlinkedHandler,
     EventListener,
@@ -523,7 +522,7 @@ class TestEventUnlinkedHandler(AbstractTestDeleteFragmentHandler):
             handler.handle_event("irrelevant")
         assert not error.value.requeue
         assert mock_parse_event.call_count == 1
-        args = ([("dc_identifier_localid", mock_parse_event().media_id)], 1)
+        args = ([("dc_identifier_localid", mock_parse_event().media_id), ("IsFragment", 1)], 1)
         assert mock_get_fragment.call_args[0] == args
         assert mock_get_fragment.call_count == 1
         assert mock_parse_fragment.call_count == 1
@@ -562,7 +561,7 @@ class TestObjectDeletedHandler(AbstractTestDeleteFragmentHandler):
             handler.handle_event("irrelevant")
         assert not error.value.requeue
         assert mock_parse_event.call_count == 1
-        args = ([("dc_identifier_localid", mock_parse_event().media_id)], 1)
+        args = ([("dc_identifier_localid", mock_parse_event().media_id), ("IsFragment", 1)], 1)
         assert mock_get_fragment.call_args[0] == args
         assert mock_get_fragment.call_count == 1
         assert mock_parse_fragment.call_count == 1


### PR DESCRIPTION
When an essenceUnlinkedEvent or objectDeletedEvent comes in we need
to delete the fragment with the given media ID. Although it should not
occur we need to be sure that we don't delete the main fragment
(= the essence).