### PR TITLE
dev-1211 Requeue if connection error to MH occurs

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -77,6 +77,12 @@ class BaseHandler(ABC):
                 error_response=error.response.text,
                 query_key_values=query_key_values
             )
+        except RequestException as error:
+            raise NackException(
+                "Unable to connect to MediaHaven",
+                error=error,
+                requeue=True
+            )
         return response_dict
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -220,6 +220,21 @@ class AbstractBaseHandler(ABC):
         assert mh_client_mock.get_fragment.call_count == 1
         assert mh_client_mock.get_fragment.call_args[0][0] == key_values
 
+    def test_get_fragment_request_exception(self, handler):
+        mh_client_mock = handler.mh_client
+        # Raise a HTTP Error when calling method
+        request_exception = RequestException()
+        handler.mh_client.get_fragment.side_effect = request_exception
+
+        key_values = [("key", "value")]
+        with pytest.raises(NackException) as error:
+            handler._get_fragment(key_values)
+        assert error.value.requeue
+        assert error.value.kwargs["error"] == request_exception
+
+        assert mh_client_mock.get_fragment.call_count == 1
+        assert mh_client_mock.get_fragment.call_args[0][0] == key_values
+
 
 class TestEventLinkedHandler(AbstractBaseHandler):
     @pytest.fixture


### PR DESCRIPTION
When querying MediaHaven to retrieve a media object, a connection error
can occur. No destructive action has been taken at this point and a
connection error should be temporary, so requeuing the Rabbit message
is advised.