### PR TITLE
DEV-1405 Add DEEWEE info to fragment metadata

### DIFF
--- a/app/services/mediahaven.py
+++ b/app/services/mediahaven.py
@@ -138,14 +138,14 @@ class MediahavenClient:
 
     @retry(RetryException)
     @__authenticate
-    def add_metadata_to_fragment(self, fragment_id: str, media_id: str, pid: str) -> bool:
+    def add_metadata_to_fragment(self, fragment_id: str, media_id: str, pid: str, ie_type: str) -> bool:
         headers = self._construct_headers()
 
         # Construct the URL to POST to
         url = f'{self.url}{fragment_id}'
 
         # Create the payload
-        sidecar = self._construct_metadata(media_id, pid)
+        sidecar = self._construct_metadata(media_id, pid, ie_type)
         data = {"metadata": sidecar, "reason": "essenceLinked: add mediaID and PID to fragment"}
 
         # Send the POST request, as multipart/form-data
@@ -165,8 +165,8 @@ class MediahavenClient:
 
         return response.status_code == 204
 
-    def _construct_metadata(self, media_id: str, pid: str) -> str:
-        """Create the sidecar XML to upload the media id metadata.
+    def _construct_metadata(self, media_id: str, pid: str, ie_type: str) -> str:
+        """Create the sidecar XML to upload the metadata.
 
         Returns:
             str -- The metadata sidecar XML.
@@ -182,6 +182,12 @@ class MediahavenClient:
         local_ids = etree.SubElement(dynamic, "dc_identifier_localids")
         # /Dynamic/dc_identifier_localids/MEDIA_ID
         etree.SubElement(local_ids, "MEDIA_ID").text = media_id
+        # /Dynamic/object_level
+        etree.SubElement(dynamic, "object_level").text = "ie"
+        # /Dynamic/object_use
+        etree.SubElement(dynamic, "object_use").text = "archive_master"
+        # /Dynamic/ie_type
+        etree.SubElement(dynamic, "ie_type").text = ie_type
 
         return etree.tostring(
             root,

--- a/tests/services/test_mediahaven.py
+++ b/tests/services/test_mediahaven.py
@@ -36,12 +36,13 @@ class TestMediahaven:
     def test_construct_metadata(self, mediahaven_client):
         media_id = "media id"
         pid = "pid"
+        ie_type = "video"
 
         # Load in XML schema
         schema = etree.XMLSchema(file=construct_filename("mhs.xsd"))
 
         # Create the sidecar XML
-        xml = mediahaven_client._construct_metadata(media_id, pid)
+        xml = mediahaven_client._construct_metadata(media_id, pid, ie_type)
         tree = etree.parse(BytesIO(xml.encode("utf-8")))
 
         # Assert validness according to schema
@@ -56,6 +57,9 @@ class TestMediahaven:
         )
         assert m_id_element[0].text == media_id
         assert tree.xpath("mhs:Dynamic/PID", namespaces=NSMAP)[0].text == pid
+        assert tree.xpath("mhs:Dynamic/object_level", namespaces=NSMAP)[0].text == "ie"
+        assert tree.xpath("mhs:Dynamic/object_use", namespaces=NSMAP)[0].text == "archive_master"
+        assert tree.xpath("mhs:Dynamic/ie_type", namespaces=NSMAP)[0].text == ie_type
 
     @pytest.mark.parametrize(
         "status, code, message",
@@ -80,6 +84,7 @@ class TestMediahaven:
         fragment_id = "fragment_id"
         media_id = "media_id"
         pid = "PID"
+        ie_type = "video"
 
-        assert not mediahaven_client.add_metadata_to_fragment(fragment_id, media_id, pid)
+        assert not mediahaven_client.add_metadata_to_fragment(fragment_id, media_id, pid, ie_type)
         assert sleep_mock.call_count == NUMBER_OF_TRIES

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -331,14 +331,14 @@ class TestEventLinkedHandler(AbstractBaseHandler):
         assert not error.value.requeue
 
     @pytest.mark.parametrize(
-        "fragment, type",
+        "fragment, ie_type",
         [
             ({"MediaDataList": [{"Administrative": {"Type": "video"}}]}, "video"),
             ({"wrong": "video"}, None)
         ]
     )
-    def test_parse_ie_type(self, handler, fragment, type):
-        assert handler._parse_ie_type(fragment) == type
+    def test_parse_ie_type(self, handler, fragment, ie_type):
+        assert handler._parse_ie_type(fragment) == ie_type
 
     def test_get_pid(self, handler):
         pid_service_mock = handler.pid_service


### PR DESCRIPTION
Add `object_level`, `object_use` en `ie_type` to the fragment metadata:
 - object_level: "ie"
 - object_use: "archive_master"
 - ie_type: "video" or "audio"