### PR TITLE
DEV-1413 Remove all fragments for a localid

### DIFF
--- a/app/services/mediahaven.py
+++ b/app/services/mediahaven.py
@@ -78,7 +78,6 @@ class MediahavenClient:
 
         params_dict: dict = {
             "q": query,
-            "nrOfResults": 1,
         }
         # Encode the spaces in the query parameters as %20 and not +
         params = urllib.parse.urlencode(params_dict, quote_via=urllib.parse.quote)


### PR DESCRIPTION
The number of returned results was hardcoded limited to 1. If there is a
metadata collateral linked to the fragment, two fragments will be found
but only one would be returned. They both need to be removed.