### PR TITLE
DEV-1447 Make timestamp of event timezone-aware

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -175,7 +175,7 @@ class EssenceLinkedHandler(BaseHandler):
 
         # Build metadata request XML
         xml = self._generate_get_metadata_request_xml(
-            datetime.now().isoformat(),
+            datetime.now().astimezone().isoformat(), #Local timezone-aware timestamp
             media_id,  # Correlation_id is the media_id
             media_id,
         )

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -315,6 +315,8 @@ class TestEventLinkedHandler(AbstractBaseHandler):
         assert mock_add_metadata.call_count == 1
         assert mock_generate_get_metadata_request_xml.call_count == 1
         assert handler.rabbit_client.send_message.call_count == 1
+        dt_string = mock_generate_get_metadata_request_xml.call_args[0][0]
+        assert type(datetime.strptime(dt_string, "%Y-%m-%dT%H:%M:%S.%f%z")) is datetime
         assert handler.rabbit_client.send_message.call_args[0][0] == "xml"
         assert handler.rabbit_client.send_message.call_args[0][1] == handler.routing_key
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -316,7 +316,7 @@ class TestEventLinkedHandler(AbstractBaseHandler):
         assert mock_generate_get_metadata_request_xml.call_count == 1
         assert handler.rabbit_client.send_message.call_count == 1
         dt_string = mock_generate_get_metadata_request_xml.call_args[0][0]
-        assert type(datetime.strptime(dt_string, "%Y-%m-%dT%H:%M:%S.%f%z")) is datetime
+        assert isinstance(datetime.strptime(dt_string, "%Y-%m-%dT%H:%M:%S.%f%z"), datetime)
         assert handler.rabbit_client.send_message.call_args[0][0] == "xml"
         assert handler.rabbit_client.send_message.call_args[0][1] == handler.routing_key
 


### PR DESCRIPTION
Add the timezone information in the timestamp node of the getMetadataRequest
event