### PR TITLE
DEV-1409 add queue name and consumer tag to startup logging

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -495,5 +495,4 @@ class EventListener:
     def start(self):
         # Start listening for incoming messages
         self.log.info(f"Waiting for messages on queue {self.queue_name}...")
-        self.consumer_tag = self.rabbit_client.listen(self.handle_message)
-        self.log.info(f"Consumer tag is: {self.consumer_tag}...")
+        self.rabbit_client.listen(self.handle_message)

--- a/app/app.py
+++ b/app/app.py
@@ -444,6 +444,7 @@ class EventListener:
             self.log.error("Connection to RabbitMQ failed.")
             raise error
         self.pid_service = PIDService(self.config["pid-service"]["URL"])
+        self.queue_name = self.config["rabbitmq"]["queue"]
         self.essence_linked_rk = self.config["rabbitmq"]["essence_linked_routing_key"]
         self.essence_unlinked_rk = self.config["rabbitmq"]["essence_unlinked_routing_key"]
         self.object_deleted_rk = self.config["rabbitmq"]["object_deleted_routing_key"]
@@ -493,5 +494,6 @@ class EventListener:
 
     def start(self):
         # Start listening for incoming messages
-        self.log.info("Start to listen for incoming essence events...")
-        self.rabbit_client.listen(self.handle_message)
+        self.log.info(f"Waiting for messages on queue {self.queue_name}...")
+        self.consumer_tag = self.rabbit_client.listen(self.handle_message)
+        self.log.info(f"Consumer tag is: {self.consumer_tag}...")

--- a/app/services/rabbit.py
+++ b/app/services/rabbit.py
@@ -48,7 +48,10 @@ class RabbitClient:
         except pika.exceptions.AMQPConnectionError as ce:
             raise ce
 
-    def listen(self, on_message_callback, queue=None):
+    def listen(self, on_message_callback, queue=None) -> str:
+
+        self.consumer_tag = 'Not yet created'
+
         if queue is None:
             queue = self.rabbitConfig["queue"]
 
@@ -60,7 +63,7 @@ class RabbitClient:
                     channel.basic_qos(
                         prefetch_count=self.prefetch_count, global_qos=False
                     )
-                    channel.basic_consume(
+                    self.consumer_tag = channel.basic_consume(
                         queue=queue, on_message_callback=on_message_callback
                     )
 
@@ -83,3 +86,4 @@ class RabbitClient:
             self.channel.stop_consuming()
 
         self.connection.close()
+        return self.consumer_tag

--- a/app/services/rabbit.py
+++ b/app/services/rabbit.py
@@ -48,7 +48,7 @@ class RabbitClient:
         except pika.exceptions.AMQPConnectionError as ce:
             raise ce
 
-    def listen(self, on_message_callback, queue=None) -> str:
+    def listen(self, on_message_callback, queue=None):
 
         self.consumer_tag = 'Not yet created'
 
@@ -66,6 +66,7 @@ class RabbitClient:
                     self.consumer_tag = channel.basic_consume(
                         queue=queue, on_message_callback=on_message_callback
                     )
+                    self.log.info(f"Consumer tag is: {self.consumer_tag}...")
 
                     channel.start_consuming()
                 except pika.exceptions.StreamLostError:
@@ -86,4 +87,3 @@ class RabbitClient:
             self.channel.stop_consuming()
 
         self.connection.close()
-        return self.consumer_tag

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,24 @@
+viaa:
+    logging:
+      level: DEBUG
+app:
+    mediahaven: 
+      host: !ENV ${MEDIAHAVEN_HOST}
+      username: !ENV ${MEDIAHAVEN_USERNAME}
+      password: !ENV ${MEDIAHAVEN_PASSWORD}
+    rabbitmq:
+      host: !ENV ${RABBITMQ_HOST}
+      port: 5672
+      username: !ENV ${RABBITMQ_USERNAME}
+      password: !ENV ${RABBITMQ_PASSWORD}
+      queue: !ENV ${RABBITMQ_QUEUE}
+      exchange: !ENV ${RABBITMQ_EXCHANGE}
+      essence_linked_routing_key: !ENV ${RABBITMQ_ESSENCE_LINKED_ROUTING_KEY}
+      essence_unlinked_routing_key: !ENV ${RABBITMQ_ESSENCE_UNLINKED_ROUTING_KEY}
+      object_deleted_routing_key: !ENV ${RABBITMQ_OBJECT_DELETED_ROUTING_KEY}
+      get_metadata_routing_key: !ENV ${RABBITMQ_GET_METADATA_ROUTING_KEY}
+      dead_letter_exchange: !ENV ${RABBITMQ_DEAD_LETTER_EXCHANGE}
+      exchange_type: topic
+      prefetch_count: !ENV ${RABBITMQ_PREFETCH_COUNT}
+    pid-service:
+      URL: !ENV ${PID_URL}

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from unittest.mock import patch, MagicMock
 
 import pytest
+import logging
 from lxml import etree
 from requests.exceptions import HTTPError, RequestException
 
@@ -21,14 +22,12 @@ from app.app import (
 from app.helpers.events_parser import EssenceEvent, InvalidEventException
 from tests.resources.resources import load_resource, construct_filename
 
-
 @pytest.fixture
 def http_error():
     response = MagicMock()
     response.status_code = 400
     response.text = "error"
     return HTTPError(response=response)
-
 
 class TestEventListener:
     @pytest.fixture
@@ -176,7 +175,14 @@ class TestEventListener:
         assert mock_nack.call_args[0][1].message == "error"
         assert mock_nack.call_args[0][2] == mock_channel
         assert mock_nack.call_args[0][3] == 1
+    
+    def test_startup_logs(self, caplog,event_listener):
+        logger = logging.getLogger(__name__)
+        logger.info(event_listener.start())
 
+        # Check if startup messages are logged
+        assert 'Waiting for' in (caplog.text)
+        assert 'Consumer tag is' in (caplog.text)
 
 class AbstractBaseHandler(ABC):
     @pytest.mark.parametrize(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -180,9 +180,8 @@ class TestEventListener:
         logger = logging.getLogger(__name__)
         logger.info(event_listener.start())
 
-        # Check if startup messages are logged
+        # Check if startup message is logged
         assert 'Waiting for' in (caplog.text)
-        assert 'Consumer tag is' in (caplog.text)
 
 class AbstractBaseHandler(ABC):
     @pytest.mark.parametrize(


### PR DESCRIPTION
Log now looks something like this:
```
INFO     app.app:app.py:497 Waiting for messages on queue mock_queue...
INFO     app.app:app.py:499 Consumer tag is: <MagicMock name='RabbitClient().listen()' id='140594156496640'>...
```
Added a new `test_startup_logs` test event in `test_app.py`, which tests if these messages are logged. To manually also confirm the validity of the type and values of `queue_name` and `consumer_tag` shown in the logs, you can make the test fail to see the logs in the pytest error output.

Config.yml.example was renamed to config.yml after confirmation from Matti, because 9 tests look for `pid-service` in config.yml, and they fail if the filename is wrong. Config.yml uses ENV vars and no longer any secrets. Whether it's OK that tests rely on config.yml I don't know.